### PR TITLE
Make header design less top-heavy

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -21,17 +21,17 @@
         .container {
             max-width: 1200px;
             margin: 0 auto;
-            padding: 2rem;
+            padding: 1rem 2rem 2rem 2rem;
         }
 
         header {
             text-align: center;
-            margin-bottom: 3rem;
+            margin-bottom: 1rem;
         }
 
         h1 {
             color: white;
-            font-size: 2.5rem;
+            font-size: 1.8rem;
             margin-bottom: 0.5rem;
             text-shadow: 0 2px 4px rgba(0,0,0,0.3);
         }

--- a/static/live.html
+++ b/static/live.html
@@ -21,17 +21,17 @@
         .container {
             max-width: 1400px;
             margin: 0 auto;
-            padding: 2rem;
+            padding: 1rem 2rem 2rem 2rem;
         }
 
         header {
             text-align: center;
-            margin-bottom: 2rem;
+            margin-bottom: 1rem;
         }
 
         h1 {
             color: white;
-            font-size: 2.5rem;
+            font-size: 1.8rem;
             margin-bottom: 0.5rem;
             text-shadow: 0 2px 4px rgba(0,0,0,0.3);
         }


### PR DESCRIPTION
This PR addresses issue #12 by making the header design less prominent and giving more space to the content stream.

## Changes
- Reduced h1 font size from 2.5rem to 1.8rem for more compact appearance
- Reduced header margin-bottom from 2-3rem to 1rem to give more space to content
- Reduced container top padding from 2rem to 1rem to reduce overall header height
- Applied changes consistently to both index.html and live.html

Fixes #12

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced vertical spacing and font size in the header area for a more compact layout on affected pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->